### PR TITLE
Stop FBP service of the session when the window is closed

### DIFF
--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -257,7 +257,6 @@
                 $scope.run = function() {
                     if ($scope.isServiceRunning) {
                         //Post stop service
-                        console.log("STOP");
                         $http.post('/api/fbp/stop').success(function(data) {
                             if (data == 1) {
                                alert("FBP Service failed to stop");
@@ -405,6 +404,14 @@
                             //Saving previous file
                             $scope.saveFile(filePath, editor.getSession().getValue());
                         }
+                    }
+
+                    if ($scope.isServiceRunning) {
+                        $http.post('/api/fbp/stop').success(function(data) {
+                            if (data == 1) {
+                                alert("FBP Service failed to stop. Process should be stopped manually");
+                            }
+                        });
                     }
                 });
 


### PR DESCRIPTION
When implementing the login system, it will be able to let the services
running when the window of the browser is closed.

Without this patch the guest session may be renewed and the coder will
not be able to stop the service. Then, the service will stay haging out
until the next restart of the system.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
