### PR TITLE
Remove after clause on soletta-dev-app-server.service

### DIFF
--- a/scripts/units/soletta-dev-app-server.service.in
+++ b/scripts/units/soletta-dev-app-server.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=Run Soletta Development Application server
-After=warn-boot.service
 
 [Service]
 ExecStart=/usr/bin/NODE_BIN_NAME PATH/server/app.js 1> /dev/null 2>&1


### PR DESCRIPTION
If the user does not have warn-boot.service this server will never autostart
waiting warn-boot servrice to start.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
