### PR TITLE
Custom configuration server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,15 @@ Depending of the nodejs installation the command might be:
 
 ## Server configuration
 
-The sever configuration file can be found on server/configuration.json
+Default sever configuration file can be found in path ```server/configuration.json```.
 
-The configuration file has the following attributes:
+The server accepts a configuration file as a parameter, to do it just pass the path of the custom configuration file when running the server for example:
+
+        node server/app.js /tmp/my_custom_configuration.json
+
+If no argument is provided it will get the default server configuration file.
+
+#### Configuration attributes
 
     server_port:
          The port listened by the server. Default: 3000

--- a/server/app.js
+++ b/server/app.js
@@ -44,7 +44,15 @@
 
     try {
         var app = express();
-        var jConf = getConfigurationJson();
+        var jConf;
+        var args = process.argv.slice(2);
+        var server = process.argv.slice(1)[0];
+        console.log(server)
+        if (args.length === 0 || server.indexOf("protractor")) {
+            jConf = getConfigurationJson();
+        } else {
+            jConf = getConfigurationJson(args[0]);
+        }
 
         app.use(session({
             genid: function(req) {

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -29,14 +29,19 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module.exports = function () {
     var jConf = null;
-    this.getConfigurationJson = function() {
+    this.getConfigurationJson = function(confPath) {
         try {
             //Verify if it is first run
             if (!jConf) {
                 var fs = require('fs');
                 var path = require('path');
-                var server_folder = path.join(__dirname, '..', 'server');
-                var file = fs.readFileSync(server_folder + '/configuration.json', 'utf8');
+                var file;
+                if (!confPath) {
+                    var server_folder = path.join(__dirname, '..', 'server');
+                    file = fs.readFileSync(server_folder + '/configuration.json', 'utf8');
+                } else {
+                    file = fs.readFileSync(confPath, 'utf8');
+                }
                 jConf = JSON.parse(file);
                 return jConf;
             } else {


### PR DESCRIPTION
It allows to pass a custom configuration file as an argument.

This patch also update documentation.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
