### PR TITLE
Change server default port from 3000 to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If no argument is provided it will get the default server configuration file.
 #### Configuration attributes
 
     server_port:
-         The port listened by the server. Default: 3000
+         The port listened by the server. Default: 8080
 
     server_output:
           Choose if you want the server to show its output.

--- a/server/configuration.json
+++ b/server/configuration.json
@@ -1,5 +1,5 @@
 {
-    "server_port": 3000,
+    "server_port": 8080,
     "server_output": true,
     "server_user_home_dir": "/tmp",
     "sessions_dir" : "./sessions",

--- a/test_case/00_run_server.js
+++ b/test_case/00_run_server.js
@@ -3,5 +3,5 @@ var http = require('http'),
 
 before(function() {
     server = http.createServer(require('../server/app.js'));
-    browser.baseUrl = 'http://localhost:3000';
+    browser.baseUrl = 'http://localhost:8080';
 });


### PR DESCRIPTION
To be more friendly user it is good to put it in a common port

Depending on the linux distro it may ask to be root when running
the server

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
