### PR TITLE
fix: remove unneeded error check

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -102,31 +102,22 @@
         var spawn = require('child_process').spawn;
         var code = req.query.code;
         var stdout = "";
-        var error = false;
 
         if (code) {
             execOnServer('echo "' + code + '" > ' + tmp_dir(current_user(req)) + 'fbp_svg.fbp', function (returns) {
                 var child_dot = spawn('sol-fbp-to-dot', ['--fbp', tmp_dir(current_user(req)) + 'fbp_svg.fbp',
                                      '--dot', tmp_dir(current_user(req)) + 'fbp_runner.dot']);
-                child_dot.stderr.on('data', function(data) {
-                    error = true;
-                    stdout = "Failed to run sol-fbp-to-dot on server";
-                });
                 child_dot.on('close', function(code) {
-                    if (error === true) {
+                    var child_svg =  spawn('dot', ['-Tsvg', tmp_dir(current_user(req)) + 'fbp_runner.dot']);
+                    child_svg.stdout.on('data', function(data) {
+                        stdout += data;
+                    });
+                    child_svg.stderr.on('data', function(data) {
+                        stdout = "Failed to run dot command";
+                    });
+                    child_svg.on('close', function(code) {
                         res.send(stdout);
-                    } else {
-                        var child_svg =  spawn('dot', ['-Tsvg', tmp_dir(current_user(req)) + 'fbp_runner.dot']);
-                        child_svg.stdout.on('data', function(data) {
-                            stdout += data;
-                        });
-                        child_svg.stderr.on('data', function(data) {
-                            stdout = "Failed to run dot command";
-                        });
-                        child_svg.on('close', function(code) {
-                            res.send(stdout);
-                        });
-                    }
+                    });
                 });
             });
         } else {


### PR DESCRIPTION
It was caught some warn messages that were misleading the Devapp to identify
unneeded error.

The warn message comes from Soletta and it was reported to be
checked.

In any case if an wrong fbp code is sent to the server it will cause error
when trying to generate the svg file from it.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
