### PR TITLE
Fix: nodejs pushing unreadable messages to journal

### DIFF
--- a/server/tools.js
+++ b/server/tools.js
@@ -121,7 +121,9 @@ module.exports = function () {
                             line_block = line_block.replace("-- Reboot --","");
                         }
                         json_block = JSON.parse(line_block);
-                        journald.push(json_block);
+                        if(json_block.SYSLOG_IDENTIFIER !== "node") {
+                            journald.push(json_block);
+                        }
                     } catch (err) {
                         console.log(err);
                         console.log(line_block);


### PR DESCRIPTION
Node is pushing unreadable messages on journalctl containing only
array of numbers such as:
"[ 27, 91, 48, 109, 112...]"

Since after some tests this is the only message the node send to
the journal, it was decided to remove any message coming from the
syslog called node.

This will not affect any warn/error messages that comes from the
server.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
