### PR TITLE
Remove unneeded Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-default: install
-
-install:
-	./install.sh


### PR DESCRIPTION
This Makefile was added to give compatibility with clearlinux crosscompilation.
Since it was necessary to create others patches in other to make soletta
dev-app to work the next release we can include a patch there with this
make unneded makefile.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
