### PR TITLE
Change port in use error to be human readable

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -100,6 +100,13 @@
             }
         });
 
+        server.once('error', function(err) {
+            if (err.code === 'EADDRINUSE') {
+                console.log('Error: Could not run the Soletta Dev-App server.' +
+                            '\nPort ' + jConf.server_port + ' is already in use');
+            }
+        });
+
         module.exports = app;
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
If there is a process using the port that Soletta Dev-App is
configure to run. Nodejs will print an understandable error.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
