### PR TITLE
syntax highlight: fix non-blue uppercase var name - V2

### DIFF
--- a/client/js/ace/mode-fbp.js
+++ b/client/js/ace/mode-fbp.js
@@ -54,15 +54,14 @@ var ShHighlightRules = function() {
     var pointFloat = "(?:(?:" + intPart + "?" + fraction + ")|(?:" + intPart + "\\.))";
     var exponentFloat = "(?:(?:" + pointFloat + "|" +  intPart + ")" + ")";
     var floatNumber = "(?:" + exponentFloat + "|" + pointFloat + ")";
-    var fileDescriptor = "(?:&" + intPart + ")";
-    var fileDescriptor = "[a-zA-Z0-9_-]+\\/[a-zA-Z0-9_-]+";
+    var nodeTypes = "[(]([^:)]+)[:)]|\\)";
 
-    var variableName = "[a-zA-Z_][a-zA-Z0-9_]*";
-    var variable = "(?:(?:\\$" + variableName + ")|(?:" + variableName + "=))";
+    var nodeOptions = "[a-zA-Z_][a-zA-Z0-9_]*";
+    var variable = "(?:(?:\\$" + nodeOptions + ")|(?:" + nodeOptions + "=))";
 
     var builtinVariable = "(?:\\$(?:SHLVL|\\$|\\!|\\?))";
 
-    var func = "[A-Z0-9]+";
+    var ports = " [a-zA-Z_][a-zA-Z0-9_]*(|\\[[0-9]+\\]) ";
 
     this.$rules = {
         "start" : [{
@@ -153,11 +152,11 @@ var ShHighlightRules = function() {
             token : "variable",
             regex : variable
         }, {
-            token : "support.function",
-            regex : func
+            token : "variable.parameter",
+            regex : ports
         }, {
             token : "support.function",
-            regex : fileDescriptor
+            regex : nodeTypes
         }, {
             token : "string",           // ' string
             start : "'", end : "'"


### PR DESCRIPTION
When the nodetype consists in upper case letter it wasn't coloring
the whole name.

This patch also fix float number that was having different colors after the
point. Such as: 1.2

The 2 was be pink and the 1 was blue.

Also, this patch contains changes in var name to be more human readable.

Differences from V1:
       - Node options should accept uppercase cases as @barbieri suggested.
       - Ports brackets should contain only number only and lowercase as @barbieri suggested.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
