### PR TITLE
Run FBP program in repo instead of copying stucture to tmp

### DIFF
--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -22,6 +22,7 @@
         function ($compile, $scope, $http, $interval, $document, broadcastService,
                   FetchFileFactory, usSpinnerService, svConf) {
                 var isRunningSyntax = false;
+                var runningFBP;
                 var promiseCheckSyntax;
                 var promiseServiceStatus;
                 var promiseRunViewer;
@@ -290,7 +291,7 @@
                     $http.get('/api/journald',
                     {
                         params: {
-                            "unit_name": "fbp-runner@"
+                            "unit_path": runningFBP,
                         }
                     }).success(function(data) {
                         $scope.RunViewer = data;
@@ -302,11 +303,14 @@
                 $scope.run = function() {
                     if ($scope.isServiceRunning) {
                         //Post stop service
-                        $http.post('/api/fbp/stop').success(function(data) {
-                            if (data == 1) {
-                               alert("FBP Service failed to stop");
-                            }
-                        });
+                        $http.post('/api/fbp/stop',
+                            {
+                                params: {"fbp_path": runningFBP}
+                            }).success(function(data) {
+                                if (data == 1) {
+                                   alert("FBP Service failed to stop");
+                                }
+                            });
                     } else if ($scope.fbpType === true && $scope.buttonSyncDisabled === false) {
                         var fbpCode = editor.getSession().getValue();
                         var fbpName = $scope.fileName;
@@ -315,14 +319,18 @@
                         if (conf === "none") {
                             conf = null;
                         }
+                        if (!filePath) {
+                            filePath = "/tmp/cached.fbp";
+                        }
                         $http.post('/api/fbp/run',
                                 {params: {
-                                    "fbp_name": fbpName,
+                                    "fbp_path": filePath,
                                     "code": fbpCode,
                                     "conf": conf
                                 }
                             }).success(function(data) {
                                 if (data == 0) {
+                                    runningFBP = filePath;
                                     $scope.openRunDialog();
                                 } else {
                                     alert("FBP Failed to run");
@@ -344,11 +352,15 @@
                 window.onbeforeunload = onBeforeUnload_Handler;
                 function onBeforeUnload_Handler() {
                     if ($scope.isServiceRunning) {
-                        $http.post('/api/fbp/stop').success(function(data) {
-                            if (data == 1) {
-                                alert("FBP Service failed to stop. Process should be stopped manually");
-                            }
-                        });
+                        $http.post('/api/fbp/stop',
+                                {params: {
+                                    "fbp_path": runningFBP
+                                }
+                            }).success(function(data) {
+                                if (data == 1) {
+                                    alert("FBP Service failed to stop. Process should be stopped manually");
+                                }
+                            });
                     }
 
                     if ($scope.shouldSave === true) {
@@ -368,13 +380,14 @@
                         }
                         $http.get('/api/check/fbp',
                                 {params: {
+                                             "fbp_path": filePath,
                                              "code": fbpCode,
                                              "conf": conf
                                          }
                                 }).success(function(data) {
                                     $scope.FBPSyntax = data.trim();
-                                    var errorline = data.match(/fbp_syntax\.fbp:[0-9]+:[0-9]+/g);
-                                    var errorDesc = data.split(/fbp_syntax\.fbp:[0-9]+:[0-9]+/g);
+                                    var errorline = data.match(/.+\.fbp:[0-9]+:[0-9]+/g);
+                                    var errorDesc = data.split(/.+\.fbp:[0-9]+:[0-9]+/g);
                                     editor.getSession().removeMarker(markId);
                                     editor.getSession().clearAnnotations();
                                     if (errorline) {
@@ -651,23 +664,23 @@
                 };
 
                 $scope.getServiceStatus = function () {
-                    $http.get('/api/service/status',
-                            {params: {
-                                         "service": "fbp-runner.service"
-                                     }
+                        if (runningFBP) {
+                            $http.get('/api/service/status',
+                            {
+                                params: { "fbp_path": runningFBP }
                             }).success(function(data) {
-                                $scope.startServiceStatus();
-                                $scope.ServiceStatus = data.trim();
-                                if ($scope.ServiceStatus.indexOf("active (running)") > -1) {
-                                    $scope.isServiceRunning = true;
-                                } else {
-                                    $scope.isServiceRunning = false;
-                                }
-                                $scope.ServiceStatus = $scope.ServiceStatus.replace(/since.*;/,"");
-                            }).error(function(){
-                                $scope.startServiceStatus();
-                                $scope.ServiceStatus = "Failed to get service information";
-                            });
+                                    $scope.ServiceStatus = data.trim();
+                                    if ($scope.ServiceStatus.indexOf("active (running)") > -1) {
+                                        $scope.isServiceRunning = true;
+                                    } else {
+                                        $scope.isServiceRunning = false;
+                                    }
+                                    $scope.ServiceStatus = $scope.ServiceStatus.replace(/since.*;/,"");
+                                }).error(function(){
+                                    $scope.ServiceStatus = "Failed to get service information";
+                                });
+                        }
+                        $scope.startServiceStatus();
                 };
 
                 $scope.refreshTree = function () {

--- a/scripts/fbp-runner.sh
+++ b/scripts/fbp-runner.sh
@@ -20,11 +20,11 @@ export SOL_LOG_PRINT_FUNCTION="journal"
 if [ $# -eq 3 ]; then
     export SOL_FLOW_MODULE_RESOLVER_CONFFILE=$3
 fi
-USER_TMP="$2"
-echo "USER_TMP="$USER_TMP
-SERVICE="fbp-runner@"$(systemd-escape $USER_TMP)
+FBP_PATH="$2"
+echo "FBP_PATH="$FBP_PATH
+SERVICE="fbp-runner@"$(systemd-escape $FBP_PATH)
 echo "SERVICE="$SERVICE
-SCRIPT="$USER_TMP/fbp_runner.fbp"
+SCRIPT="$FBP_PATH"
 systemctl stop $SERVICE
 if [ $1 == "start" ]; then
     syntax=`sol-fbp-runner -c $SCRIPT | grep OK`


### PR DESCRIPTION
The running method was focused in building a run environment before running
the project.

When DECLARE was created, Soletta Dev-App started creating a
building environment wrongly when DECLARE was used with relative PATH.

With this patch Soletta Dev-App will run the project directly in the
right PATH of the repo, making DECLARE working with Relative paths.

Fixes the issue: Devapp wasn't finding the external FBP when using DECLARE in a
relative path.
