### PR TITLE
Run FBP program in repo instead of copying stucture to tmp v2

### DIFF
--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -526,6 +526,52 @@
 
                 }
 
+                $scope.createProject = function () {
+                    var dialog = $('<div></div>').
+                                 html($compile('<input class="inputControls"' +
+                                               ' type="text" style="width: 256px; outline: 0;"' +
+                                               ' ng-model="prj_name" />')($scope)).
+                    dialog({
+                        title: "Choose the name of the project",
+                        autoOpen: false,
+                        modal: true,
+                        position: { at: "center top"},
+                        height: 167,
+                        width: 300,
+                        show: { effect: "fade", duration: 300 },
+                        hide: {effect: "fade", duration: 300 },
+                        resizable: 'disable',
+                        buttons: {
+                            "Create": function() {
+                                var name = "/" + $scope.prj_name;
+                                if (name) {
+                                    $http.post('/api/git/repo/create/project',
+                                    {
+                                        params: {
+                                            "project_name": name
+                                        }
+                                    }).success(function(data) {
+                                        $scope.refreshTree();
+                                    }).error(function(){
+                                        alert("Oh uh, something went wrong. Try again");
+                                    });
+                                } else {
+                                    alert("Oh uh, something went wrong. Try again");
+                                }
+                                $(this).dialog("close");
+                            },
+                            Cancel: function() {
+                                $(this).dialog("close");
+                                }
+                            },
+                            close: function(ev, ui){
+                                $(this).dialog("close");
+                            }
+                    });
+                    dialog.dialog("open");
+
+                };
+
                 $scope.newFolder = function () {
                     var file = filePath;
                     if (isLeaf) {
@@ -548,7 +594,7 @@
                         hide: {effect: "fade", duration: 300 },
                         resizable: 'disable',
                         buttons: {
-                            "Apply": function() {
+                            "Create": function() {
                                 var name = "/" + $scope.folder_name;
                                 if (name) {
                                     $http.post('/api/git/repo/create/folder',
@@ -600,7 +646,7 @@
                           hide: {effect: "fade", duration: 300 },
                           resizable: 'disable',
                           buttons: {
-                              "Apply": function() {
+                              "Create": function() {
                                   var name = "/" + $scope.file_name;
                                   if (name) {
                                       $http.post('/api/git/repo/create/file',

--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -75,6 +75,7 @@
                     var _l = data.node.li_attr;
                     var repos = _l.id.split("repos")[1];
                     var rfinal = repos.split("/");
+                    var previousContent = editor.getSession().getValue();
                     $scope.subFolder = rfinal[1];
                     $scope.folder = rfinal[2];
                     $scope.getConfigurationlist(_l.id);
@@ -83,7 +84,6 @@
                     if (_l.isLeaf) {
                         FetchFileFactory.fetchFile(_l.base).then(function(data) {
                             var _d = data.data;
-                            var previousContent = editor.getSession().getValue();
                             if (typeof _d == 'object') {
                                 _d = JSON.stringify(_d, undefined, 2);
                             }
@@ -108,25 +108,25 @@
                         });
                         $scope.root = false;
                     } else {
-                        filePath = _l.id;
-                        $scope.fileName = ': ' + filePath.split("/").pop(); //getting the selected node name
-                        editor.setReadOnly(true);
-                        editor.setHighlightActiveLine(false);
                         if (data.node.parent === "#") {
                             $scope.root = true;
-                            $scope.setEditorContent('Please select a file to view its contents', null, null);
+                            $scope.setEditorContent('Please select a file to view its contents', previousContent, filePath);
                         } else {
                             if (data.node.parents[1] === "#") {
                                 $scope.root = true;
-                                $scope.setEditorContent('Please select a file to view its contents', null, null);
+                                $scope.setEditorContent('Please select a file to view its contents', previousContent, filePath);
                             } else {
                                 if (!isLeaf) {
-                                    $scope.setEditorContent('Please select a file to view its contents', null, null);
+                                    $scope.setEditorContent('Please select a file to view its contents', previousContent, filePath);
                                 }
                                 $scope.root = false;
                             }
                         }
+                        filePath = _l.id;
+                        $scope.fileName = ': ' + filePath.split("/").pop(); //getting the selected node name
                         $scope.fbpType = false;
+                        editor.setReadOnly(true);
+                        editor.setHighlightActiveLine(false);
                     }
                 };
 
@@ -444,7 +444,7 @@
                 };
 
                 $scope.saveFile = function(path, body) {
-                    if (body && path && isLeaf) {
+                    if (body && path) {
                         $http.get('api/file/write',
                                   {params: {
                                       "file_path": path,

--- a/scripts/fbp-runner.sh
+++ b/scripts/fbp-runner.sh
@@ -20,11 +20,11 @@ export SOL_LOG_PRINT_FUNCTION="journal"
 if [ $# -eq 3 ]; then
     export SOL_FLOW_MODULE_RESOLVER_CONFFILE=$3
 fi
-USER_TMP="$2"
-echo "USER_TMP="$USER_TMP
-SERVICE="fbp-runner@"$(systemd-escape $USER_TMP)
+FBP_PATH="$2"
+echo "FBP_PATH="$FBP_PATH
+SERVICE="fbp-runner@"$(systemd-escape $FBP_PATH)
 echo "SERVICE="$SERVICE
-SCRIPT="$USER_TMP/fbp_runner.fbp"
+SCRIPT="$FBP_PATH"
 systemctl stop $SERVICE
 if [ $1 == "start" ]; then
     syntax=`sol-fbp-runner -c $SCRIPT | grep OK`

--- a/server/routes.js
+++ b/server/routes.js
@@ -390,6 +390,21 @@
         });
     });
 
+    router.post('/api/git/repo/create/project', function (req, res) {
+        var project_name = req.body.params.project_name;
+        if (!project_name) {
+            res.status(400).send("Failed to get project name");
+        }
+        execOnServer('mkdir ' + home_dir(current_user(req)) + project_name,
+                     function(returns) {
+            if (returns.error === true) {
+                res.status(400).send("Failed to run command on server");
+            } else {
+                res.send(returns.message);
+            }
+        });
+    })
+
     router.post('/api/git/repo/create/folder', function (req, res) {
         var folder_path = req.body.params.folder_path;
         if (!folder_path) {

--- a/server/tools.js
+++ b/server/tools.js
@@ -49,7 +49,9 @@ module.exports = function () {
         fs.readdir(_p, function(err, list) {
             if (list) {
                 for (var i = list.length - 1; i >= 0; i--) {
-                    resp.push(processNode(_p, list[i]));
+                    if (list[i].charAt(0) !== ".") {
+                        resp.push(processNode(_p, list[i]));
+                    }
                 }
             }
             res.json(resp);

--- a/server/tools.js
+++ b/server/tools.js
@@ -78,6 +78,22 @@ module.exports = function () {
         };
     };
 
+    this.generateHiddenPath = function(path) {
+        var array_path;
+        var fbp_name;
+        var fbp_path;
+
+        if (!path) {
+            return null;
+        }
+
+        array_path = path.split("/");
+        fbp_name = array_path.pop();
+        fbp_path = array_path.join("/");
+
+        return fbp_path + "/." + fbp_name;
+    }
+
     this.writeFile = function(path, body) {
         var fs = require('fs');
         var err = fs.writeFileSync(path, body);

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -174,6 +174,7 @@
                     <!-- DROP DOWN MENU !-->
                     <div class="dropdown" style="position: fixed; z-index: 9999;" id="menu-1">
                         <ul class="dropdown-menu" role="menu">
+                            <li><a class="pointer" role="menuitem" tabindex="1" ng-click="createProject()">New project</a></li>
                             <li><a class="pointer" role="menuitem" tabindex="1" ng-click="newFolder()">Create folder</a></li>
                             <li><a class="pointer" role="menuitem" tabindex="2"  ng-click="newFile()">Create file</a></li>
                             <li><a class="pointer" role="menuitem" tabindex="3" ng-click="remove()">Remove</a></li>


### PR DESCRIPTION
The running method was focused in building a run environment before running
the project.

When DECLARE was created, Soletta Dev-App started creating a
building environment wrongly when DECLARE was used with relative PATH.

With this patch Soletta Dev-App will run the project directly in the
right PATH of the repo, making DECLARE working with Relative paths.

Fixes the issue: Devapp wasn't finding the external FBP when using DECLARE in a
relative path.

Differences from V1:
       - Mock VI behavior: By creating a "swp" file and when saving the file the swp will replace the        original copy. As talked with @otaviobp 
       - Fix: changes being lost when swithing files added.
