### PR TITLE
editor: fix remove-file issue

### DIFF
--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -209,6 +209,7 @@
                                 if(close_id) {
                                     $scope.saveFile(savePath, previousContent);
                                     editor.getSession().setValue(content);
+                                    $scope.refreshTree();
                                 } else {
                                     editor.getSession().setValue(content);
                                 }
@@ -500,6 +501,7 @@
                                     //pop * from the string
                                     if ($scope.fileName) {
                                             $scope.fileName = $scope.fileName.substring(0, $scope.fileName.length-1);
+                                            $scope.refreshTree();
                                     }
                                  }).error(function(){
                                     alert("Failed to save file on server. Try again.");


### PR DESCRIPTION
- After a file is removed it's entry is deleted from the directory view(jsTree) but the contents of it remain in the editor which enable us to make some more edits and save it again. This time the file is saved but the directory view is not updated. 
- This fix now uses refresh() function to update the directory view whenever saveFileManually() is executed.
- gitignore file should contain repos/\* as an entry as the edits done by a user in his own project need not be included in a "source code" update commit.

Signed-off-by: Kamidi Preetham kamidi@live.com
