### PR TITLE
run should not export conf var when there is no configuration file

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -218,8 +218,7 @@
                                        'SOL_FLOW_MODULE_RESOLVER_CONFFILE="' + conf + '"');
                     } else {
                         err = writeFile(env_file(current_user(req)),
-                                     'FBP_FILE="' + fbp_path + '"\n' +
-                                     'SOL_FLOW_MODULE_RESOLVER_CONFFILE=""');
+                                     'FBP_FILE="' + fbp_path + '"\n');
                     }
                     if (!err) {
                         getConfigureFile(current_user(req), conf, function (error) {


### PR DESCRIPTION
SOL_FLOW_MODULE_RESOLVER_CONFFILE should be exported empty otherwise, Soletta
will try to load empty conf files and produce the following unwanted warnings:

WRN: ./src/shared/sol-util-file.c:181 sol_util_load_file_fd_raw() r (-1) < 0
WRN: ./src/shared/sol-util-file.c:209 sol_util_load_file_fd_buffer() r (-1) < 0
WRN: ./src/shared/sol-util-file.c:181 sol_util_load_file_fd_raw() r (-1) < 0
WRN: ./src/shared/sol-util-file.c:209 sol_util_load_file_fd_buffer() r (-1) < 0
WRN: ./src/shared/sol-util-file.c:181 sol_util_load_file_fd_raw() r (-1) < 0
WRN: ./src/shared/sol-util-file.c:209 sol_util_load_file_fd_buffer() r (-1) < 0

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
