### PR TITLE
fbp-runner: Avoid asking for the root password twice when running a FBP - V2

### DIFF
--- a/scripts/fbp-runner.sh
+++ b/scripts/fbp-runner.sh
@@ -19,9 +19,10 @@ SCRIPT="$3"
 ENV_PATH="$2"
 SERVICE="fbp-runner@"$(systemd-escape $ENV_PATH)
 
-systemctl stop $SERVICE
+if [ $1 == "stop" ]; then
+	systemctl stop $SERVICE
 
-if [ $1 == "start" ]; then
+elif [ $1 == "start" ] || [ $1 == "restart" ]; then
     syntax=`sol-fbp-runner -c $SCRIPT | grep OK`
     systemctl $1 $SERVICE
     if [ -n "$syntax" ]; then
@@ -29,11 +30,11 @@ if [ $1 == "start" ]; then
     else
         exit 1
     fi
+fi
+
+st=`systemctl status $SERVICE | grep "Active:"`
+if [ -z "$st" ]; then
+	exit 0
 else
-    st=`systemctl status $SERVICE | grep "Active:"`
-    if [ -z "$st" ]; then
-        exit 0
-    else
-        exit 1
-    fi
+	exit 1
 fi

--- a/server/routes.js
+++ b/server/routes.js
@@ -211,7 +211,7 @@
                 var fbp_path = generateHiddenPath(path);
                 if (fbp_path) {
                     err = writeFile(fbp_path, code);
-                    script = script + ' start ' + env_file(current_user(req)) + ' ' +  fbp_path;
+                    script = script + ' restart ' + env_file(current_user(req)) + ' ' +  fbp_path;
                     if (conf) {
                         err = writeFile(env_file(current_user(req)),
                                        'FBP_FILE="' + fbp_path + '"\n' +


### PR DESCRIPTION
Differences from V1:
Replace start for restart to preserve the same behavior as before.

Signed-off-by: Bruno Bottazzini bruno.bottazzini@intel.com
