### PR TITLE
V1 - Import files to Dev-App

### DIFF
--- a/client/css/app.css
+++ b/client/css/app.css
@@ -176,6 +176,43 @@ font-family: clearsans-light;
     padding-left: 10px;
     border-radius: 20px;
 }
+.inputFileControls {
+    background-color: #262a2e;
+    border: 0;
+    color: #8c8c8c;
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+}
+.inputFileControls + label {
+    font-size: 14px !important;
+    font-weight: normal;
+    font-family: clearsans !important;
+    color: #8c8c8c;
+    background-color: white;
+    display: inline-block;
+    margin-right: 10px;
+    padding: .4em 1em;
+    border-radius: 20px;
+    cursor: pointer;
+    text-align: center;
+}
+.list-item {
+    font-size: 14px !important;
+    width: auto;
+    font-weight: normal;
+    font-family: clearsans !important;
+    background-color: #262a2e;
+    margin-right: 10px;
+    padding: .3em 0.5em;
+    list-style-type: none;
+    border-radius: 13px;
+    color: #8c8c8c;
+    text-align: center;
+}
 /* Overwrite jquery ui class*/
 .ui-autocomplete-input, .ui-corner-right {
     background: none !important;

--- a/client/js/controllers/editor.js
+++ b/client/js/controllers/editor.js
@@ -831,6 +831,74 @@
                     }
                 };
 
+                $scope.filesChanged = function(elm) {
+                    $scope.files = elm.files;
+                    $scope.$apply();
+                }
+
+                $scope.importFile = function () {
+                    var file = filePath;
+                    if (file) {
+                        if (isLeaf) {
+                            var cached = file.split("/");
+                            cached.pop();
+                            file = cached.join("/");
+                        }
+                        if($scope.folder !== 'demo') {
+                        var dialog = $('<div></div>').
+                                html($compile('<form ng-submit="Upload()"><input' +
+                                            ' type="file" id="inputFile" class="inputFileControls"' +
+                                            ' onChange="angular.element(this).scope().filesChanged(this)"/>'+
+                                            ' <label for="inputFile">Select Files</label>'+
+                                            ' <li class="list-item" ng-repeat="file in files">{{file.name}}</li>'+
+                                            ' </form>')($scope)).
+                        dialog({
+                          title: "Choose file to import",
+                          autoOpen: false,
+                          modal: true,
+                          position: { at: "center top"},
+                          height: 225,
+                          width: 300,
+                          show: { effect: "fade", duration: 300 },
+                          hide: { effect: "fade", duration: 300 },
+                          resizable: 'disable',
+                          buttons: {
+                              "Upload": function() {
+                                  var formdata = new FormData();
+                                  var data=String(file);
+                                  formdata.append("upload_path", data);
+                                  angular.forEach($scope.files,function(file) {
+                                  formdata.append('file', file)
+                                  });
+                                  $http.post('/api/file/upload',formdata, {
+                                    transformRequest: angular.identity,
+                                    headers:{'Content-Type':undefined}
+                                  })
+                                    .success(function(d) {
+                                        console.log(d)
+                                        $scope.refreshTree();                                        
+                                    });
+                                  $(this).dialog("close");
+                              },
+                              Cancel: function() {
+                                  $(this).dialog("close");
+                                  }
+                              },
+                              close: function(ev, ui) {
+                                  $(this).dialog("close");
+                              }
+                      });
+                      dialog.dialog("open");
+                        }else{
+                            console.log("Error: Upload to demo folder not allowed");
+                            alert("Error: Upload to demo folder Forbidden!")
+                        }
+                    } else {
+                        console.log("Error: repository not selected");
+                        alert("Folder destination must be selected!");
+                    }
+                };
+
                 $scope.remove = function () {
                     if (filePath) {
                         var file_name = filePath.split("/").pop();
@@ -939,6 +1007,9 @@
                             break;
                         case "file.save":
                             $scope.saveFileManually();
+                            break;
+                        case "file.importfile":
+                            $scope.importFile();
                             break;
                         case "file.remove":
                             $scope.remove();

--- a/server/routes.js
+++ b/server/routes.js
@@ -378,6 +378,18 @@
         }
     });
 
+    router.post('/api/file/upload', function(req, res) {
+        upload(req,res,function(err) {
+            if(err) {
+                res.status(400).send("File Upload Failed!");
+                return;
+            }
+            else {
+                res.send("File Uploaded Successfully!");
+            }
+        })  
+    });
+
     router.post('/api/git/repo/delete/file', function (req, res) {
         var file_path = req.body.params.file_path;
         if (!file_path) {

--- a/server/tools.js
+++ b/server/tools.js
@@ -248,6 +248,17 @@ module.exports = function () {
         }
     };
 
+    this.storage = multer.diskStorage({
+        destination: function(req, file, callback) {
+            callback(null, String(req.body.upload_path)) 
+        },
+        filename: function(req, file, callback) {
+            callback(null, file.originalname)
+        }
+    });
+
+    this.upload = multer({storage: storage }).single('file');
+
     this.getServerName = function(repo_url) {
         var url_array = repo_url.split("/");
         var name = url_array.pop();

--- a/server/tools.js
+++ b/server/tools.js
@@ -17,6 +17,7 @@
 module.exports = function () {
     var fs = require('fs');
     var path = require('path');
+    var multer = require('multer');
     require('./configuration.js')();
 
     this.home_dir = function(user) {

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -190,6 +190,11 @@
                                         New File
                                     </md-button>
                                  </md-menu-item>
+                                 <md-menu-item>
+                                    <md-button ng-click="ctrl.menuAction('file.importfile', $event)">
+                                        Import File
+                                    </md-button>
+                                </md-menu-item>
                                  <md-menu-divider></md-menu-divider>
                                  <md-menu-item>
                                     <md-button ng-disabled="!shouldSave" ng-click="ctrl.menuAction('file.save', $event)">


### PR DESCRIPTION
This PR is part of implementation of issue #47 . 
Files can now be directly imported into Dev-App. Export of files from Dev-App is WIP.
- "multer" library is used. It is a middleware which handles multipart/form-data essentially used for uploading files.
- Single file can be imported at a time.
- Prevents import of files into "demo" folder.
  
  Signed-off-by: Kamidi Preetham [kamidi@live.com](mailto:kamidi@live.com)
