### PR TITLE
V1 - Export Files from Dev-App

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -393,6 +393,20 @@
         })  
     });
 
+    router.get('/api/file/download', function(req, res) {
+        var file_path = req.query.file;
+        if ( file_path.search('soletta-dev-app/repos') > -1 ) {
+            var file_name = file_path.split('/').pop();
+            if (fs.statSync(file_path)) {
+                res.download(file_path, file_name);
+            } else {
+                res.sendStatus(400);
+            }
+        } else {
+            res.sendStatus(400);
+        }
+    });    
+
     router.post('/api/git/repo/delete/file', function (req, res) {
         var file_path = req.body.params.file_path;
         if (!file_path) {

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -197,6 +197,11 @@
                                         Import File
                                     </md-button>
                                 </md-menu-item>
+                                <md-menu-item>
+                                    <md-button ng-click="ctrl.menuAction('file.exportfile', $event)">
+                                        Export File
+                                    </md-button>
+                                </md-menu-item>
                                  <md-menu-divider></md-menu-divider>
                                  <md-menu-item>
                                     <md-button ng-disabled="!shouldSave" ng-click="ctrl.menuAction('file.save', $event)">


### PR DESCRIPTION
This PR is part of implementation of task #47 .
- Files can now be exported from desired Dev-App working repository.
- HTTP GET request sent to 'api/file/download' with query string as the path of file to be downloaded will return a 'Save As' dialog in the browser.
- Only a single file at a time can be downloaded. No support for direct folder download.
- File inclusion vulnerability is put in check so that files outside Dev-App's repos folder (such as /etc/passwd ) cannot be accessed.
- SetTimeout() is used for making this work in Firefox.
